### PR TITLE
Change ofAnimationFrame to more generic ofCallback

### DIFF
--- a/src/elmish/elmish.fs
+++ b/src/elmish/elmish.fs
@@ -41,18 +41,17 @@ module Cmd =
             }
         [bind >> Async.StartImmediate]
 
-    /// Command that will schedule animation frame callback and map the result 
-    /// into success or error (of exception) 
-    let ofAnimationFrame (task:float->_) (ofSuccess:_->'msg) (ofError:_->'msg) : Cmd<'msg> =
-        let bind dispatch =
-            let animate ts =
+    /// Command that will evaluate a function that triggers a callback then
+    /// maps the result into success or error (of exception) 
+    let ofCallback (task:'a->('b->unit)->unit) (arg:'a) (ofSuccess:_->'msg) (ofError:_->'msg) : Cmd<'msg> =
+        let bind (dispatch:'msg -> unit) =
+            let completed result =
                 try 
-                    task ts
+                    result
                     |> (ofSuccess >> dispatch)
                 with x -> 
                     x |> (ofError >> dispatch)
-            Fable.Import.Browser.window.requestAnimationFrame (Fable.Import.Browser.FrameRequestCallback animate)
-            |> ignore
+            task arg completed
         [bind]
 
     /// Command to evaluate a simple function and map the result 

--- a/src/elmish/elmish.fs
+++ b/src/elmish/elmish.fs
@@ -41,6 +41,20 @@ module Cmd =
             }
         [bind >> Async.StartImmediate]
 
+    /// Command that will schedule animation frame callback and map the result 
+    /// into success or error (of exception) 
+    let ofAnimationFrame (task:float->_) (ofSuccess:_->'msg) (ofError:_->'msg) : Cmd<'msg> =
+        let bind dispatch =
+            let animate ts =
+                try 
+                    task ts
+                    |> (ofSuccess >> dispatch)
+                with x -> 
+                    x |> (ofError >> dispatch)
+            Fable.Import.Browser.window.requestAnimationFrame (Fable.Import.Browser.FrameRequestCallback animate)
+            |> ignore
+        [bind]
+
     /// Command to evaluate a simple function and map the result 
     /// into success or error (of exception) 
     let ofFunc (task:'a->_) (arg:'a) (ofSuccess:_->'msg) (ofError:_->'msg) : Cmd<'msg> =

--- a/src/elmish/package.json
+++ b/src/elmish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-elmish",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Elm-like architecture core for Fable F# apps.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This still allows you to use requestAnimationFrame:
```
Cmd.ofCallback (fun _ c -> Browser.window.requestAnimationFrame(fun _ -> c()) |> ignore) () (fun _ -> Advance) (fun _ -> invalidOp "Can't happen")
```
But doesn't limit it to just requestAnimationFrame.