### PR TITLE
very lame attempt to fix #22

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -11,6 +11,4 @@ if errorlevel 1 (
   exit /b %errorlevel%
 )
 
-call packages\Npm.js\tools\npm.cmd install
-
 packages\FAKE\tools\FAKE.exe build.fsx %*

--- a/build.cmd
+++ b/build.cmd
@@ -11,4 +11,6 @@ if errorlevel 1 (
   exit /b %errorlevel%
 )
 
+call packages\Npm.js\tools\npm.cmd install
+
 packages\FAKE\tools\FAKE.exe build.fsx %*

--- a/build.fsx
+++ b/build.fsx
@@ -32,6 +32,12 @@ Target "Build" (fun _ ->
     projects
     |> Seq.iter (fun s -> 
                     let dir = IO.Path.GetDirectoryName s
+                    printf "Installing: %s\n" dir
+                    Npm (fun p ->
+                        { p with
+                            Command = Install Standard
+                            WorkingDirectory = dir
+                        })
                     printf "Building: %s\n" dir
                     Npm (fun p ->
                         { p with

--- a/build.fsx
+++ b/build.fsx
@@ -11,6 +11,10 @@ let buildDir  = "./build/"
 // Filesets
 let projects  =
       !! "src/*/fableconfig.json"
+let installs  =
+      !! "package.json"
+      ++ "src/*/package.json"
+      ++ "samples/*/package.json"
 
 // Fable projects
 let fables  =
@@ -28,8 +32,8 @@ Target "Clean" (fun _ ->
     CleanDirs [buildDir]
 )
 
-Target "Build" (fun _ ->
-    projects
+Target "Install" (fun _ ->
+    installs
     |> Seq.iter (fun s -> 
                     let dir = IO.Path.GetDirectoryName s
                     printf "Installing: %s\n" dir
@@ -37,7 +41,14 @@ Target "Build" (fun _ ->
                         { p with
                             Command = Install Standard
                             WorkingDirectory = dir
-                        })
+                        }))
+)
+
+
+Target "Build" (fun _ ->
+    projects
+    |> Seq.iter (fun s -> 
+                    let dir = IO.Path.GetDirectoryName s
                     printf "Building: %s\n" dir
                     Npm (fun p ->
                         { p with
@@ -50,6 +61,7 @@ Target "Samples" (fun _ ->
     fables
     |> Seq.iter (fun s -> 
                     let dir = IO.Path.GetDirectoryName s
+                    printf "Installing: %s\n" dir
                     printf "Building: %s\n" dir
                     Npm (fun p ->
                         { p with
@@ -76,6 +88,7 @@ Target "Publish-Elmish-React" (fun _ ->
 
 // Build order
 "Clean"
+  ==> "Install"
   ==> "Build"
   
 // start build

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,3 +2,4 @@ source https://nuget.org/api/v2
 
 nuget FAKE
 nuget Microsoft.Research.InferNET
+nuget npm.js

--- a/paket.lock
+++ b/paket.lock
@@ -2,3 +2,6 @@ NUGET
   remote: https://www.nuget.org/api/v2
     FAKE (4.39)
     Microsoft.Research.InferNET (2.6.41114.1)
+    Node.js (5.3)
+    Npm.js (2.13.1)
+      Node.js (>= 0.12.7)


### PR DESCRIPTION
fixing only `build.cmd`, not `build.sh`. `npm install` should be probably called in `build.fsx` the same way I did it for the projects.

Not optimized at all, `npm install` should be probably not called when `node_modules` folder is present (?)

