### PR TITLE
Close div tags in the samples.

### DIFF
--- a/samples/react/counter/index.html
+++ b/samples/react/counter/index.html
@@ -5,7 +5,7 @@
 </head>
 <body class="app-container">
 		<!-- [body] -->
-		<div id="elmish-app" class="elmish-app" />
+		<div id="elmish-app" class="elmish-app"></div>
     <script src="./public/bundle.js"></script>
 		<!-- [/body] -->
 </body>

--- a/samples/react/navigation/index.html
+++ b/samples/react/navigation/index.html
@@ -5,7 +5,7 @@
 </head>
 <body class="app-container">
 		<!-- [body] -->
-		<div id="elmish-app" class="elmish-app" />
+		<div id="elmish-app" class="elmish-app"></div>
     <script src="./public/bundle.js"></script>
 		<!-- [/body] -->
 </body>


### PR DESCRIPTION
I needed to close the tags with `</div>` otherwise it's breaks in the browser when adding others stags.

Example:

```html
<body class="app-container">
     <!-- [body] -->
    <div id="elmish-app" class="elmish-app" />
    <div id="second-container" />
    <script src="./public/bundle.js"></script>
     <!-- [/body] -->
</body>
```

When executed in the browser `second-container` doesn't exist because it think it's inside the `elmish-app` and the Program is update the DOM erasing it.