### PR TITLE
[next] update yarn.lock and misc package.json updates

### DIFF
--- a/samples/react/navigation/app.fsproj
+++ b/samples/react/navigation/app.fsproj
@@ -10,8 +10,7 @@
     <Compile Include="app.fs" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-compile-fsc" Version="1.0.0-preview2-*" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-060000" PrivateAssets="All" />
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="FSharp.Core" Version="4.1.*" />
     <PackageReference Include="Fable.Core" Version="1.0.0-narumi-*" />
     <DotNetCliToolReference Include="dotnet-fable" Version="1.0.0-narumi-*" />

--- a/samples/react/package.json
+++ b/samples/react/package.json
@@ -15,7 +15,7 @@
     "babel-preset-es2015": "^6.24.0",
     "fable-elmish": "^0.9.0-beta-4",
     "fable-elmish-react": "^0.9.0-beta-4",
-    "fable-elmish-debugger": "^0.9.0-beta-1",
+    "fable-elmish-debugger": "^0.9.0-beta-4",
     "fable-loader": "^1.0.0-narumi-8",
     "fable-powerpack": "^1.0.0-narumi-2",
     "fable-react": "^1.0.0-narumi-2",

--- a/samples/react/yarn.lock
+++ b/samples/react/yarn.lock
@@ -1144,29 +1144,29 @@ fable-core@^1.0.0-narumi-8:
   version "1.0.0-narumi-8"
   resolved "https://registry.yarnpkg.com/fable-core/-/fable-core-1.0.0-narumi-8.tgz#dff875fdbe0d0af051595b799ba62b1d46162ad2"
 
-fable-elmish-debugger@^0.9.0-beta-1:
-  version "0.9.0-beta-1"
-  resolved "https://registry.yarnpkg.com/fable-elmish-debugger/-/fable-elmish-debugger-0.9.0-beta-1.tgz#201caf95343cd384afb658740bef51e0ad62c4e1"
+fable-elmish-debugger@^0.9.0-beta-4:
+  version "0.9.0-beta-4"
+  resolved "https://registry.yarnpkg.com/fable-elmish-debugger/-/fable-elmish-debugger-0.9.0-beta-4.tgz#ac1e5d58ef3996680ec61d5639889ac53243eed7"
 
-fable-elmish-react@^0.9.0-beta-2:
-  version "0.9.0-beta-2"
-  resolved "https://registry.yarnpkg.com/fable-elmish-react/-/fable-elmish-react-0.9.0-beta-2.tgz#46c0da74a2023747acdf6c78704dec92e7f474a3"
+fable-elmish-react@^0.9.0-beta-4:
+  version "0.9.0-beta-4"
+  resolved "https://registry.yarnpkg.com/fable-elmish-react/-/fable-elmish-react-0.9.0-beta-4.tgz#62a0e76ecf606f592b1384ee81ca2a098b52590f"
 
-fable-elmish@^0.9.0-beta-2:
-  version "0.9.0-beta-2"
-  resolved "https://registry.yarnpkg.com/fable-elmish/-/fable-elmish-0.9.0-beta-2.tgz#fed91beeb889d1fbe840e041fc06ed39c9100cb3"
+fable-elmish@^0.9.0-beta-4:
+  version "0.9.0-beta-4"
+  resolved "https://registry.yarnpkg.com/fable-elmish/-/fable-elmish-0.9.0-beta-4.tgz#edace352b85ca79a9e4a959941e02e32bfd332e5"
 
 fable-loader@^1.0.0-narumi-8:
   version "1.0.0-narumi-8"
   resolved "https://registry.yarnpkg.com/fable-loader/-/fable-loader-1.0.0-narumi-8.tgz#a912c73ebebcbc3c5635eceb1f5931064f211842"
 
-fable-powerpack@^1.0.0-narumi-1:
-  version "1.0.0-narumi-1"
-  resolved "https://registry.yarnpkg.com/fable-powerpack/-/fable-powerpack-1.0.0-narumi-1.tgz#7563021873ca3929c50c88b7f8443339c627981d"
+fable-powerpack@^1.0.0-narumi-2:
+  version "1.0.0-narumi-2"
+  resolved "https://registry.yarnpkg.com/fable-powerpack/-/fable-powerpack-1.0.0-narumi-2.tgz#6ac3dc1a05bc4736d407d8f28b9abab8e1e83e43"
 
-fable-react@^1.0.0-narumi-1:
-  version "1.0.0-narumi-1"
-  resolved "https://registry.yarnpkg.com/fable-react/-/fable-react-1.0.0-narumi-1.tgz#658e8a062b0ffedb3dd012964cbe961c99d67046"
+fable-react@^1.0.0-narumi-2:
+  version "1.0.0-narumi-2"
+  resolved "https://registry.yarnpkg.com/fable-react/-/fable-react-1.0.0-narumi-2.tgz#3d19f34d8cc9a6f169b1d72a6ec4d6f326c56af9"
 
 faye-websocket@^0.10.0:
   version "0.10.0"

--- a/samples/snabbdom/package.json
+++ b/samples/snabbdom/package.json
@@ -15,7 +15,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.0",
     "fable-elmish": "^0.9.0-beta-4",
-    "fable-elmish-debugger": "^0.1.0",
+    "fable-elmish-debugger": "^0.9.0-beta-4",
     "fable-elmish-snabbdom": "^0.9.0-beta-4",
     "fable-loader": "^1.0.0-narumi-8",
     "fable-powerpack": "^1.0.0-narumi-2",

--- a/samples/snabbdom/yarn.lock
+++ b/samples/snabbdom/yarn.lock
@@ -1145,29 +1145,29 @@ fable-core@^1.0.0-narumi-8:
   version "1.0.0-narumi-8"
   resolved "https://registry.yarnpkg.com/fable-core/-/fable-core-1.0.0-narumi-8.tgz#dff875fdbe0d0af051595b799ba62b1d46162ad2"
 
-fable-elmish-debugger@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/fable-elmish-debugger/-/fable-elmish-debugger-0.1.2.tgz#11f2d20d7e676b0f68521d24e54dcd315efd33d6"
+fable-elmish-debugger@^0.9.0-beta-4:
+  version "0.9.0-beta-4"
+  resolved "https://registry.yarnpkg.com/fable-elmish-debugger/-/fable-elmish-debugger-0.9.0-beta-4.tgz#ac1e5d58ef3996680ec61d5639889ac53243eed7"
 
-fable-elmish-react@^0.9.0-beta-1:
-  version "0.9.0-beta-1"
-  resolved "https://registry.yarnpkg.com/fable-elmish-react/-/fable-elmish-react-0.9.0-beta-1.tgz#6306d10a5e50fbbd3a32fa8a42dbf1a774a17fca"
+fable-elmish-snabbdom@^0.9.0-beta-4:
+  version "0.9.0-beta-4"
+  resolved "https://registry.yarnpkg.com/fable-elmish-snabbdom/-/fable-elmish-snabbdom-0.9.0-beta-4.tgz#0cc7cc082a9856f750964fadf32366bc74fd0225"
 
-fable-elmish@^0.9.0-beta-1:
-  version "0.9.0-beta-1"
-  resolved "https://registry.yarnpkg.com/fable-elmish/-/fable-elmish-0.9.0-beta-1.tgz#e955604f74f13cbf81c2263918e658f3ffc4752c"
+fable-elmish@^0.9.0-beta-4:
+  version "0.9.0-beta-4"
+  resolved "https://registry.yarnpkg.com/fable-elmish/-/fable-elmish-0.9.0-beta-4.tgz#edace352b85ca79a9e4a959941e02e32bfd332e5"
 
 fable-loader@^1.0.0-narumi-8:
   version "1.0.0-narumi-9"
   resolved "https://registry.yarnpkg.com/fable-loader/-/fable-loader-1.0.0-narumi-9.tgz#30d9a04acfdcadcc37c78cab125da9f629ac5ff1"
 
-fable-powerpack@^1.0.0-narumi-1:
-  version "1.0.0-narumi-1"
-  resolved "https://registry.yarnpkg.com/fable-powerpack/-/fable-powerpack-1.0.0-narumi-1.tgz#7563021873ca3929c50c88b7f8443339c627981d"
+fable-powerpack@^1.0.0-narumi-2:
+  version "1.0.0-narumi-2"
+  resolved "https://registry.yarnpkg.com/fable-powerpack/-/fable-powerpack-1.0.0-narumi-2.tgz#6ac3dc1a05bc4736d407d8f28b9abab8e1e83e43"
 
-fable-react@^1.0.0-narumi-1:
-  version "1.0.0-narumi-1"
-  resolved "https://registry.yarnpkg.com/fable-react/-/fable-react-1.0.0-narumi-1.tgz#658e8a062b0ffedb3dd012964cbe961c99d67046"
+fable-react@^1.0.0-narumi-2:
+  version "1.0.0-narumi-2"
+  resolved "https://registry.yarnpkg.com/fable-react/-/fable-react-1.0.0-narumi-2.tgz#3d19f34d8cc9a6f169b1d72a6ec4d6f326c56af9"
 
 faye-websocket@^0.10.0:
   version "0.10.0"

--- a/src/elmish-react/package.json
+++ b/src/elmish-react/package.json
@@ -15,6 +15,6 @@
   "author": "Eugene Tolmachev",
   "license": "Apache-2.0",
   "devDependencies": {
-    "fable-react": "^1.0.0-narumi-1"
+    "fable-react": "^1.0.0-narumi-2"
   }
 }

--- a/src/elmish-react/yarn.lock
+++ b/src/elmish-react/yarn.lock
@@ -3,5 +3,5 @@
 
 
 fable-react@^1.0.0-narumi-1:
-  version "1.0.0-narumi-1"
-  resolved "https://registry.yarnpkg.com/fable-react/-/fable-react-1.0.0-narumi-1.tgz#658e8a062b0ffedb3dd012964cbe961c99d67046"
+  version "1.0.0-narumi-2"
+  resolved "https://registry.yarnpkg.com/fable-react/-/fable-react-1.0.0-narumi-2.tgz#3d19f34d8cc9a6f169b1d72a6ec4d6f326c56af9"

--- a/src/elmish/package.json
+++ b/src/elmish/package.json
@@ -16,6 +16,6 @@
   "author": "Eugene Tolmachev",
   "license": "Apache-2.0",
   "devDependencies": {
-    "fable-powerpack": "^1.0.0-narumi-1"
+    "fable-powerpack": "^1.0.0-narumi-2"
   }
 }

--- a/src/elmish/yarn.lock
+++ b/src/elmish/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-fable-powerpack@^1.0.0-narumi-1:
-  version "1.0.0-narumi-1"
-  resolved "https://registry.yarnpkg.com/fable-powerpack/-/fable-powerpack-1.0.0-narumi-1.tgz#7563021873ca3929c50c88b7f8443339c627981d"
+fable-powerpack@^1.0.0-narumi-2:
+  version "1.0.0-narumi-2"
+  resolved "https://registry.yarnpkg.com/fable-powerpack/-/fable-powerpack-1.0.0-narumi-2.tgz#6ac3dc1a05bc4736d407d8f28b9abab8e1e83e43"


### PR DESCRIPTION
Some packages were out of sync. Once I updated those and fixed a few others I was able to run the basic samples and had full intellisense with ionide.