### PR TITLE
update debugger serialization for fable v1

### DIFF
--- a/src/elmish-debugger/Fable.Import.RemoteDev.fs
+++ b/src/elmish-debugger/Fable.Import.RemoteDev.fs
@@ -27,7 +27,8 @@ module RemoteDev =
           port : int
           hostname : string
           secure : bool
-          getActionType : (obj->obj) option }
+          getActionType : (obj->obj) option
+          serialize : obj }
     
     type Action = 
         { ``type``: string

--- a/src/elmish-debugger/debugger.fs
+++ b/src/elmish-debugger/debugger.fs
@@ -5,30 +5,45 @@ open Fable.Core
 
 [<RequireQualifiedAccess>]
 module Debugger =
+    open FSharp.Reflection
+
+    let inline private duName (x:'a) = 
+        match FSharpValue.GetUnionFields(x, typeof<'a>) with
+        | case, _ -> case.Name
+
+    let [<PassGenericsAttribute>] private getCase cmd : obj =
+        createObj ["type" ==> duName cmd
+                   "msg" ==> cmd]
+
     type ConnectionOptions =
         | ViaExtension
         | Remote of address:string * port:int
         | Secure of address:string * port:int
 
     let connect =
-        let inline getCase cmd : obj = createObj ["type" ==> unbox cmd?tag
-                                                  "fields" ==> cmd?fields]
+        let serialize = createObj ["replacer" ==> fun _ v -> deflate v]
 
         function
-        | ViaExtension -> { Options.remote = false; hostname = "localhost"; port = 8000; secure = false; getActionType = Some getCase }
-        | Remote (address,port) -> { Options.remote = true; hostname = address; port = port; secure = false; getActionType = None }
-        | Secure (address,port) -> { Options.remote = true; hostname = address; port = port; secure = true; getActionType = None }
+        | ViaExtension -> { Options.remote = false; hostname = "localhost"; port = 8000; secure = false; getActionType = Some getCase; serialize = serialize }
+        | Remote (address,port) -> { Options.remote = true; hostname = address; port = port; secure = false; getActionType = None; serialize = serialize }
+        | Secure (address,port) -> { Options.remote = true; hostname = address; port = port; secure = true; getActionType = None; serialize = serialize }
         >> connectViaExtension
 
 [<RequireQualifiedAccess>]
 module Program =
     open Elmish
 
+    [<Emit("JSON.parse($0)")>]
+    let private parse str : obj = jsNative
+
     [<PassGenericsAttribute>]
     let withDebuggerUsing (connection:Connection) (program : Program<'a,'model,'msg,'view>) : Program<'a,'model,'msg,'view> =
         let init a =
             let (model,cmd) = program.init a
-            connection.init (model, None)
+            // simple looking one liner to do a recursive deflate
+            // needed otherwise extension gets F# obj
+            let decoded = model |> toJson |> parse
+            connection.init (decoded, None)
             model,cmd
 
         let update msg model : 'model * Cmd<'msg> =

--- a/src/elmish-debugger/debugger.fs
+++ b/src/elmish-debugger/debugger.fs
@@ -11,7 +11,7 @@ module Debugger =
         match FSharpValue.GetUnionFields(x, typeof<'a>) with
         | case, _ -> case.Name
 
-    let [<PassGenericsAttribute>] inline private getCase cmd : obj =
+    let inline private getCase cmd : obj =
         createObj ["type" ==> duName cmd
                    "msg" ==> cmd]
 


### PR DESCRIPTION
* use `deflate` with remotedev's `serialize.reducer` option
* workaround for init serialization
* use new reflection apis for DU name