### PR TITLE
Refactor module names. Avoid namespace collision for nested components

### DIFF
--- a/src/templates/react/Content/FableElmishReactTemplate.fsproj
+++ b/src/templates/react/Content/FableElmishReactTemplate.fsproj
@@ -5,8 +5,8 @@
   <ItemGroup>
     <!-- Global to the app -->
     <Compile Include="src/Global.fs" />
-    <!-- About -->
-    <Compile Include="src/About/View.fs" />
+    <!-- Info -->
+    <Compile Include="src/Info/View.fs" />
     <!-- Counter -->
     <Compile Include="src/Counter/Types.fs" />
     <Compile Include="src/Counter/State.fs" />

--- a/src/templates/react/Content/src/App.fs
+++ b/src/templates/react/Content/src/App.fs
@@ -1,4 +1,4 @@
-module App
+module App.View
 
 open Elmish
 open Elmish.Browser.Navigation
@@ -7,8 +7,8 @@ open Fable.Core
 open Fable.Core.JsInterop
 open Fable.Import
 open Fable.Import.Browser
-open Types.App
-open State.App
+open Types
+open App.State
 open Global
 open Global.Helpers
 
@@ -41,9 +41,9 @@ let root model dispatch =
 
   let pageHtml =
     function
-    | Page.About -> Views.About.root
-    | Counter -> Views.Counter.root model.counter (CounterMsg >> dispatch)
-    | Home -> Views.Home.root model.home (HomeMsg >> dispatch)
+    | Page.About -> Info.View.root
+    | Counter -> Counter.View.root model.counter (CounterMsg >> dispatch)
+    | Home -> Home.View.root model.home (HomeMsg >> dispatch)
 
   div
     []
@@ -51,7 +51,7 @@ let root model dispatch =
         [ ClassName "navbar-bg" ]
         [ div
             [ ClassName "container" ]
-            [ Views.Navbar.root ] ]
+            [ Navbar.View.root ] ]
       div
         [ ClassName "section" ]
         [ div

--- a/src/templates/react/Content/src/Counter/State.fs
+++ b/src/templates/react/Content/src/Counter/State.fs
@@ -1,7 +1,7 @@
-module State.Counter
+module Counter.State
 
 open Elmish
-open Types.Counter
+open Types
 
 let init () : Model * Cmd<Msg> =
   0, []

--- a/src/templates/react/Content/src/Counter/Types.fs
+++ b/src/templates/react/Content/src/Counter/Types.fs
@@ -1,4 +1,4 @@
-module Types.Counter
+module Counter.Types
 
 type Model = int
 

--- a/src/templates/react/Content/src/Counter/View.fs
+++ b/src/templates/react/Content/src/Counter/View.fs
@@ -1,9 +1,9 @@
-module Views.Counter
+module Counter.View
 
 open Fable.Core
 open Fable.Helpers.React
 open Fable.Helpers.React.Props
-open Types.Counter
+open Types
 
 let simpleButton txt action dispatch =
   div

--- a/src/templates/react/Content/src/Home/State.fs
+++ b/src/templates/react/Content/src/Home/State.fs
@@ -1,7 +1,7 @@
-module State.Home
+module Home.State
 
 open Elmish
-open Types.Home
+open Types
 
 let init () : Model * Cmd<Msg> =
   "", []

--- a/src/templates/react/Content/src/Home/Types.fs
+++ b/src/templates/react/Content/src/Home/Types.fs
@@ -1,4 +1,4 @@
-module Types.Home
+module Home.Types
 
 type Model = string
 

--- a/src/templates/react/Content/src/Home/View.fs
+++ b/src/templates/react/Content/src/Home/View.fs
@@ -1,10 +1,10 @@
-module Views.Home
+module Home.View
 
 open Fable.Core
 open Fable.Core.JsInterop
 open Fable.Helpers.React
 open Fable.Helpers.React.Props
-open Types.Home
+open Types
 
 let root model dispatch =
   div

--- a/src/templates/react/Content/src/Info/View.fs
+++ b/src/templates/react/Content/src/Info/View.fs
@@ -1,4 +1,4 @@
-module Views.About
+module Info.View
 
 open Fable.Helpers.React
 open Fable.Helpers.React.Props

--- a/src/templates/react/Content/src/Navbar/View.fs
+++ b/src/templates/react/Content/src/Navbar/View.fs
@@ -1,4 +1,4 @@
-module Views.Navbar
+module Navbar.View
 
 open Fable.Helpers.React
 open Fable.Helpers.React.Props

--- a/src/templates/react/Content/src/State.fs
+++ b/src/templates/react/Content/src/State.fs
@@ -1,11 +1,11 @@
-module State.App
+module App.State
 
 open Elmish
 open Elmish.Browser.Navigation
 open Elmish.Browser.UrlParser
 open Fable.Import.Browser
 open Global
-open Types.App
+open Types
 
 let pageParser: Parser<Page->Page,Page> =
   oneOf [
@@ -23,8 +23,8 @@ let urlUpdate (result: Option<Page>) model =
       { model with currentPage = page }, []
 
 let init result =
-  let (counter, counterCmd) = State.Counter.init()
-  let (home, homeCmd) = State.Home.init()
+  let (counter, counterCmd) = Counter.State.init()
+  let (home, homeCmd) = Home.State.init()
   let (model, cmd) =
     urlUpdate result
       { currentPage = Home
@@ -37,8 +37,8 @@ let init result =
 let update msg model =
   match msg with
   | CounterMsg msg ->
-      let (counter, counterCmd) = State.Counter.update msg model.counter
+      let (counter, counterCmd) = Counter.State.update msg model.counter
       { model with counter = counter }, Cmd.map CounterMsg counterCmd
   | HomeMsg msg ->
-      let (home, homeCmd) = State.Home.update msg model.home
+      let (home, homeCmd) = Home.State.update msg model.home
       { model with home = home }, Cmd.map HomeMsg homeCmd

--- a/src/templates/react/Content/src/Types.fs
+++ b/src/templates/react/Content/src/Types.fs
@@ -1,14 +1,13 @@
-module Types.App
+module App.Types
 
-open Types
 open Global
 
 type Msg =
-  | CounterMsg of Counter.Msg
-  | HomeMsg of Home.Msg
+  | CounterMsg of Counter.Types.Msg
+  | HomeMsg of Home.Types.Msg
 
 type Model = {
     currentPage: Page
-    counter: Counter.Model
-    home: Home.Model
+    counter: Counter.Types.Model
+    home: Home.Types.Model
   }

--- a/src/templates/react/Fable.Template.nuspec
+++ b/src/templates/react/Fable.Template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Fable.Template.Elmish.React</id>
-        <version>0.1.4</version>
+        <version>0.1.5</version>
         <description>Simple elmish application using React as a renderer</description>
         <authors>Maxime Mangel</authors>
         <language>en-US</language>


### PR DESCRIPTION
This refactor is needed when working with nested components.

This avoid namespace collision like:

```fs
module Views.Forum
//...

module Views.Forum.Thread 
// Collision here Views.Forum already defined
//...
```

New organization:
```fs
module Forum.View
//...

module Forum.Thread.View 
// Ok this time :)
//...
```

Edit: Sorry for this problem and new *major* change. 
But I didn't encounter this problem before testing on a real case app.