### PR TITLE
Fix #if DEBUG statement in the template

### DIFF
--- a/src/templates/react/Content/src/App.fs
+++ b/src/templates/react/Content/src/App.fs
@@ -74,7 +74,6 @@ Program.mkProgram init update root
 |> Program.withReact "elmish-app"
 //-:cnd
 #if DEBUG
-|> Program.withConsoleTrace
 |> Program.withDebugger
 #endif
 //+:cnd

--- a/src/templates/react/Content/src/App.fs
+++ b/src/templates/react/Content/src/App.fs
@@ -72,7 +72,10 @@ open Elmish.Debug
 Program.mkProgram init update root
 |> Program.toNavigable (parseHash pageParser) urlUpdate
 |> Program.withReact "elmish-app"
+//-:cnd
 #if DEBUG
+|> Program.withConsoleTrace
 |> Program.withDebugger
 #endif
+//+:cnd
 |> Program.run


### PR DESCRIPTION
Reference:
https://github.com/dotnet/templating/issues/587
https://github.com/dotnet/templating/issues/432

This fixes the problem with the missing lines surrounded by `#if DEBUG` in the code generated by the template, unfortunately the `//-:cnd` comments will remain too, but apparently this will be fixed with dotnet SDK 2.0.