### PR TITLE
Fixing link in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,7 @@ First of all - thanks for taking the time to contribute!
 With that in mind, elmish is a young project and as such while we welcome the contributions from non-member there are certain things we'd like to get more right than fast. To make everyone's experience as enjoyable as possible please keep the following things in mind:
 
 * Unless it's a trivial fix, consider opening an issue first to discuss it with the team.
-* If you are just looking for something to take on, check the [help wanted](/elmish/elmish/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labeled items
+* If you are just looking for something to take on, check the [help wanted](https://github.com/elmish/elmish/labels/help%20wanted) labeled items
 
 
 ### Opening an Issue


### PR DESCRIPTION
Fixing #216 the link that redirect to the issues with the "help wanted" label so it works properly.

BTW i find it funny that i found this issue searching for the "help wanted" label :D