### PR TITLE
Add exit criteria and handler

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.301"
+    "version": "3.1.301",
+    "rollForward": "minor"
   }
 }


### PR DESCRIPTION
This adds the exit criteria and handler as implemented in `master` branch (v4 alpha) to v3. The only difference is, in order to [prevent a breaking change](https://github.com/elmish/elmish/issues/162#issuecomment-962466232), I've added a separate `mapTermination` helper instead of changing the signature of `map`. If this is accepted we could also deprecate `map` and add `mapInit`, `mapUpdate`...

An alternative implementation for termination could be to have a list of disposables (so subscriptions, extensions... can easily add a cleanup) and have `run` also return an IDisposable. That would make the API similar to those for observables and also avoids the need for program "managers" (like HMR or UseElmish) to have to wrap Msg in order to terminate the program.

cc @et1975 @MangelMaxime