### PR TITLE
added DisableImplicitFSharpCoreReference

### DIFF
--- a/netstandard/Elmish.fsproj
+++ b/netstandard/Elmish.fsproj
@@ -4,6 +4,7 @@
     <Description>Elmish core for .NET apps</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DisableImplicitFSharpCoreReference>True</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../src/prelude.fs" />


### PR DESCRIPTION
Added `<DisableImplicitFSharpCoreReferencePer>true</DisableImplicitFSharpCoreReference>` per our discussion #267.
This change allows the Elmish.WPF package to keep its existing `FSharp.Core` version requirements to `Version="[6.0.5, 99]"`.

To verify, I did the following:

1) Temporarily updated elmish to v4.0.0.0-beta1
2) Added `<DisableImplicitFSharpCoreReferencePer>true</DisableImplicitFSharpCoreReference>`
3) Created a NuGet package
4) Referenced the v4.0.0.0-beta1 package locally from within the Elmish.WPF project
5) Verified that the build warnings around FSharp.Core version discrepancies were gone

**Before the change, FSharp.Core v6.0.7 was required:**
![image](https://user-images.githubusercontent.com/1030435/217032214-da46aeae-2e9b-423a-9487-37705cc1c96e.png)

**After the change, no version is listed:**
![image](https://user-images.githubusercontent.com/1030435/217032278-a00892ac-b2bd-4d4b-90bf-fd6984f25f5e.png)

This allows Elmish.WPF to resolve FSharp.Core v6.0.5, according to its minimum specified verison:  
![image](https://user-images.githubusercontent.com/1030435/217033116-92b62b13-79ac-4957-a9d7-843e62b03646.png)
