### PR TITLE
Allow passing untyped Task to Cmd.OfTask.attempt (#276)

### DIFF
--- a/src/cmd.fs
+++ b/src/cmd.fs
@@ -215,7 +215,7 @@ module Cmd =
             OfAsync.perform (task >> Async.AwaitTask) arg ofSuccess
 
         /// Command to call a task and map the error
-        let inline attempt (task: 'a -> Task<_>)
+        let inline attempt (task: 'a -> #Task)
                            (arg:'a)
                            (ofError: _ -> 'msg) : Cmd<'msg> =
             OfAsync.attempt (task >> Async.AwaitTask) arg ofError


### PR DESCRIPTION
See #276.