### PR TITLE
fix: capture error when generating "tasks" + add CmdTests suits

### DIFF
--- a/src/cmd.fs
+++ b/src/cmd.fs
@@ -84,12 +84,8 @@ module Cmd =
             let bind dispatch =
                 async {
                     try
-                        let! r = task arg |> Async.Catch
-                        dispatch (
-                            match r with
-                            | Choice1Of2 x -> ofSuccess x
-                            | Choice2Of2 x -> ofError x
-                        )
+                        let! r = task arg
+                        dispatch (ofSuccess r)
                     with x -> dispatch (ofError x)
                 }
             [bind >> start]
@@ -102,10 +98,8 @@ module Cmd =
             let bind dispatch =
                 async {
                     try
-                        let! r = task arg |> Async.Catch
-                        match r with
-                        | Choice1Of2 x -> dispatch (ofSuccess x)
-                        | _ -> ()
+                        let! r = task arg
+                        dispatch (ofSuccess r)
                     with _ -> ()
                 }
             [bind >> start]
@@ -118,10 +112,8 @@ module Cmd =
             let bind dispatch =
                 async {
                     try
-                        let! r = task arg |> Async.Catch
-                        match r with
-                        | Choice2Of2 x -> dispatch (ofError x)
-                        | _ -> ()
+                        let! _ = task arg
+                        ()
                     with x -> dispatch (ofError x)
                 }
             [bind >> start]
@@ -185,7 +177,6 @@ module Cmd =
                 try
                     (task arg)
                         .``then``(ofSuccess >> dispatch)
-                        .catch(unbox >> ofError >> dispatch)
                         |> ignore
                 with x -> x |> unbox |> ofError |> dispatch
             [bind]
@@ -208,9 +199,7 @@ module Cmd =
                     (ofError: #exn -> 'msg) : Cmd<'msg> =
             let bind dispatch =
                 try
-                    (task arg)
-                        .catch(unbox >> ofError >> dispatch)
-                        |> ignore
+                    (task arg) |> ignore
                 with x -> x |> unbox |> ofError |> dispatch
             [bind]
 #else

--- a/src/cmd.fs
+++ b/src/cmd.fs
@@ -60,7 +60,7 @@ module Cmd =
                 try
                     task arg
                     |> (ofSuccess >> dispatch)
-                with x ->
+                with _ ->
                     ()
             [bind]
 
@@ -83,10 +83,14 @@ module Cmd =
                    (ofError: _ -> 'msg) : Cmd<'msg> =
             let bind dispatch =
                 async {
-                    let! r = task arg |> Async.Catch
-                    dispatch (match r with
-                             | Choice1Of2 x -> ofSuccess x
-                             | Choice2Of2 x -> ofError x)
+                    try
+                        let! r = task arg |> Async.Catch
+                        dispatch (
+                            match r with
+                            | Choice1Of2 x -> ofSuccess x
+                            | Choice2Of2 x -> ofError x
+                        )
+                    with x -> dispatch (ofError x)
                 }
             [bind >> start]
 
@@ -97,10 +101,12 @@ module Cmd =
                     (ofSuccess: _ -> 'msg) : Cmd<'msg> =
             let bind dispatch =
                 async {
-                    let! r = task arg |> Async.Catch
-                    match r with
-                    | Choice1Of2 x -> dispatch (ofSuccess x)
-                    | _ -> ()
+                    try
+                        let! r = task arg |> Async.Catch
+                        match r with
+                        | Choice1Of2 x -> dispatch (ofSuccess x)
+                        | _ -> ()
+                    with _ -> ()
                 }
             [bind >> start]
 
@@ -111,10 +117,12 @@ module Cmd =
                     (ofError: _ -> 'msg) : Cmd<'msg> =
             let bind dispatch =
                 async {
-                    let! r = task arg |> Async.Catch
-                    match r with
-                    | Choice2Of2 x -> dispatch (ofError x)
-                    | _ -> ()
+                    try
+                        let! r = task arg |> Async.Catch
+                        match r with
+                        | Choice2Of2 x -> dispatch (ofError x)
+                        | _ -> ()
+                    with x -> dispatch (ofError x)
                 }
             [bind >> start]
 
@@ -174,10 +182,12 @@ module Cmd =
                    (ofSuccess: _ -> 'msg)
                    (ofError: #exn -> 'msg) : Cmd<'msg> =
             let bind dispatch =
-                (task arg)
-                    .``then``(ofSuccess >> dispatch)
-                    .catch(unbox >> ofError >> dispatch)
-                    |> ignore
+                try
+                    (task arg)
+                        .``then``(ofSuccess >> dispatch)
+                        .catch(unbox >> ofError >> dispatch)
+                        |> ignore
+                with x -> x |> unbox |> ofError |> dispatch
             [bind]
 
         /// Command to call `promise` block and map the success
@@ -185,9 +195,11 @@ module Cmd =
                    (arg:'a)
                    (ofSuccess: _ -> 'msg) =
             let bind dispatch =
-                (task arg)
-                    .``then``(ofSuccess >> dispatch)
-                    |> ignore
+                try
+                    (task arg)
+                        .``then``(ofSuccess >> dispatch)
+                        |> ignore
+                with _ -> ()
             [bind]
 
         /// Command to call `promise` block and map the error
@@ -195,9 +207,11 @@ module Cmd =
                     (arg:'a)
                     (ofError: #exn -> 'msg) : Cmd<'msg> =
             let bind dispatch =
-                (task arg)
-                    .catch(unbox >> ofError >> dispatch)
-                    |> ignore
+                try
+                    (task arg)
+                        .catch(unbox >> ofError >> dispatch)
+                        |> ignore
+                with x -> x |> unbox |> ofError |> dispatch
             [bind]
 #else
     open System.Threading.Tasks

--- a/tests/CmdTests.fs
+++ b/tests/CmdTests.fs
@@ -1,0 +1,207 @@
+module Elmish.CmdTests
+
+open NUnit.Framework
+open Swensen.Unquote
+open Elmish
+
+type Msg =
+    | OnError of exn
+    | OnSuccess of string
+
+
+[<Test>]
+let ``Cmd.OfAsync.either - works`` () =
+    let myTask () =
+        async {
+            return "Task completed"
+        }
+
+    let init () = "initial", Cmd.OfAsync.either myTask () OnSuccess OnError
+    let update msg _ =
+        match msg with
+        | OnError ex -> ex.Message, Cmd.none
+        | OnSuccess res -> res, Cmd.none
+    let mutable result = ""
+    let view model _ = result <- model
+    async {
+        Program.mkProgram init update view
+        |> Program.run
+    } |> Async.Start
+    System.Threading.Thread.Sleep (1_000)
+    result =! "Task completed"
+
+[<Test>]
+let ``Cmd.OfAsync.attempt - works`` () =
+    let mutable result = ""
+    let myTask () =
+        async {
+            // Cmd.OfAsync.attempt don't notifiy about success
+            // so we use a mutable variable to check if the task was called
+            result <- "Task called"
+            return "Task completed"
+        }
+    let init () = "initial", Cmd.OfAsync.attempt myTask () OnError
+    let update msg _ =
+        match msg with
+        | OnError ex -> "Error was captured", Cmd.none
+        | OnSuccess res -> res, Cmd.none
+    let view model _ = result <- model
+    async {
+        Program.mkProgram init update view
+        |> Program.run
+    } |> Async.Start
+    System.Threading.Thread.Sleep (1_000)
+    result =! "Task called"
+
+[<Test>]
+let ``Cmd.OfAsync.perform - works`` () =
+    let myTask () =
+        async {
+            return "Task completed"
+        }
+
+    let init () = "initial", Cmd.OfAsync.perform myTask () OnSuccess
+    let update msg _ =
+        match msg with
+        | OnError ex -> ex.Message, Cmd.none
+        | OnSuccess res -> res, Cmd.none
+    let mutable result = ""
+    let view model _ = result <- model
+    async {
+        Program.mkProgram init update view
+        |> Program.run
+    } |> Async.Start
+    System.Threading.Thread.Sleep (1_000)
+    result =! "Task completed"
+
+[<Test>]
+let ``Cmd.OfAsync.either - thrown exception when generating task should be captured`` () =
+    let myTask () =
+        failwith "Boom!"
+        async {
+            return "Task completed"
+        }
+
+    let init () = "initial", Cmd.OfAsync.either myTask () OnSuccess OnError
+    let update msg _ =
+        match msg with
+        | OnError ex -> ex.Message, Cmd.none
+        | OnSuccess res -> res, Cmd.none
+    let mutable result = ""
+    let view model _ = result <- model
+    async {
+        Program.mkProgram init update view
+        |> Program.run
+    } |> Async.Start
+    System.Threading.Thread.Sleep (1_000)
+    result =! "Boom!"
+
+[<Test>]
+let ``Cmd.OfAsync.attempt - thrown exception when generating task should be captured`` () =
+    let myTask () =
+        failwith "Boom!"
+        async {
+            return "Task completed"
+        }
+
+    let init () = "initial", Cmd.OfAsync.attempt myTask () OnError
+    let update msg _ =
+        match msg with
+        | OnError ex -> "Error was captured", Cmd.none
+        | OnSuccess res -> res, Cmd.none
+    let mutable result = ""
+    let view model _ = result <- model
+    async {
+        Program.mkProgram init update view
+        |> Program.run
+    } |> Async.Start
+    System.Threading.Thread.Sleep (1_000)
+    result =! "Error was captured"
+
+[<Test>]
+let ``Cmd.OfAsync.perform - thrown exception when generating task should be discarded`` () =
+    let myTask () =
+        failwith "Boom!"
+        async {
+            return "Task completed"
+        }
+
+    let init () = "initial", Cmd.OfAsync.perform myTask () OnSuccess
+    let update msg _ =
+        match msg with
+        | OnError ex -> ex.Message, Cmd.none
+        | OnSuccess res -> res, Cmd.none
+    let mutable result = ""
+    let view model _ = result <- model
+    async {
+        Program.mkProgram init update view
+        |> Program.run
+    } |> Async.Start
+    System.Threading.Thread.Sleep (1_000)
+    result =! "initial"
+
+[<Test>]
+let ``Cmd.OfAsync.either - thrown exception from inside task should be captured`` () =
+    let myTask () =
+        async {
+            failwith "Boom!"
+            return "Task completed"
+        }
+
+    let init () = "initial", Cmd.OfAsync.either myTask () OnSuccess OnError
+    let update msg _ =
+        match msg with
+        | OnError ex -> ex.Message, Cmd.none
+        | OnSuccess res -> res, Cmd.none
+    let mutable result = ""
+    let view model _ = result <- model
+    async {
+        Program.mkProgram init update view
+        |> Program.run
+    } |> Async.Start
+    System.Threading.Thread.Sleep (1_000)
+    result =! "Boom!"
+
+[<Test>]
+let ``Cmd.OfAsync.attempt - thrown exception from inside task should be captured`` () =
+    let myTask () =
+        async {
+            failwith "Boom!"
+            return "Task completed"
+        }
+
+    let init () = "initial", Cmd.OfAsync.attempt myTask () OnError
+    let update msg _ =
+        match msg with
+        | OnError ex -> "Error was captured", Cmd.none
+        | OnSuccess res -> res, Cmd.none
+    let mutable result = ""
+    let view model _ = result <- model
+    async {
+        Program.mkProgram init update view
+        |> Program.run
+    } |> Async.Start
+    System.Threading.Thread.Sleep (1_000)
+    result =! "Error was captured"
+
+[<Test>]
+let ``Cmd.OfAsync.perform - thrown exception from inside task should be discarded`` () =
+    let myTask () =
+        async {
+            failwith "Boom!"
+            return "Task completed"
+        }
+
+    let init () = "initial", Cmd.OfAsync.perform myTask () OnSuccess
+    let update msg _ =
+        match msg with
+        | OnError ex -> ex.Message, Cmd.none
+        | OnSuccess res -> res, Cmd.none
+    let mutable result = ""
+    let view model _ = result <- model
+    async {
+        Program.mkProgram init update view
+        |> Program.run
+    } |> Async.Start
+    System.Threading.Thread.Sleep (1_000)
+    result =! "initial"

--- a/tests/Elmish.Tests.fsproj
+++ b/tests/Elmish.Tests.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="SubTests.fs" />
     <Compile Include="RingTest.fs" />
     <Compile Include="ProgramTest.fs" />
+    <Compile Include="CmdTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FsCheck" Version="2.*" />


### PR DESCRIPTION
This PR fixes a bug where, if you have an exception happening before entering the `async` code then the exception would not be captured by the command.