### PR TITLE
fix: capture promise exception at runtime and not only at the creation

### DIFF
--- a/src/cmd.fs
+++ b/src/cmd.fs
@@ -177,6 +177,7 @@ module Cmd =
                 try
                     (task arg)
                         .``then``(ofSuccess >> dispatch)
+                        .catch(unbox >> ofError >> dispatch)
                         |> ignore
                 with x -> x |> unbox |> ofError |> dispatch
             [bind]
@@ -199,7 +200,9 @@ module Cmd =
                     (ofError: #exn -> 'msg) : Cmd<'msg> =
             let bind dispatch =
                 try
-                    (task arg) |> ignore
+                    (task arg)
+                        .catch(unbox >> ofError >> dispatch)
+                        |> ignore
                 with x -> x |> unbox |> ofError |> dispatch
             [bind]
 #else


### PR DESCRIPTION
Fix #302 

I tested with a local reproduction and we do need both the

- `try ... with` => capture exception during promise creation 

	```fs
	let increment model =
	    failwith "dwdw"
	    promise {
	        return model + 1
	    }
	```

- `.catch` => capture exception during promise execution

	```fs
	let increment model =
	    promise {
	        failwith "Error"
	        return model + 1
	    }
	```